### PR TITLE
Fix live reload not working when using main.js (unminified) in index.html

### DIFF
--- a/tool/dev.js
+++ b/tool/dev.js
@@ -37,7 +37,7 @@ if (mode === "development") {
       middleware: [
         async (req, res, next) => {
           if (req.url === "/main.js" || req.url === "/main.min.js") {
-            const src = await build();
+            const src = await build(req.url === "/main.min.js");
             res.setHeader("Content-Type", "text/javascript");
             res.end(src);
           } else {
@@ -57,7 +57,7 @@ if (mode === "development") {
   build();
 }
 
-async function build() {
+async function build(minify = false) {
   try {
     const src = await bundle();
 
@@ -69,7 +69,7 @@ async function build() {
     const eth = 675 * min.length * gwei * (1 / 1000000000);
     console.log(`~${eth.toFixed(4)} ETH at ${gwei} gwei`);
 
-    return min;
+    return minify ? min : src;
   } catch (err) {
     let msg = err.toString();
     if (err.frame) {

--- a/tool/dev.js
+++ b/tool/dev.js
@@ -36,7 +36,7 @@ if (mode === "development") {
       ignore: path.resolve(__dirname, "../www/*.js"),
       middleware: [
         async (req, res, next) => {
-          if (req.url === "/main.min.js") {
+          if (req.url === "/main.js" || req.url === "/main.min.js") {
             const src = await build();
             res.setHeader("Content-Type", "text/javascript");
             res.end(src);


### PR DESCRIPTION
During development it's helpful to include the non-minified `main.js` in `index.html`. The middleware only watches for changes to `main.min.js` to run the `build()` step. 

This adds `main.js` to the middleware check, and also passes whether the `min` version was requested through to `build()` as an argument, returning the appropriate bundle. Still logs out bytes based on the minified size. 